### PR TITLE
Fixes addon crash

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -34,8 +34,11 @@ def changeWebFontSize(font_size):
 		# Qt5
 		wes = QWebEngineSettings.globalSettings()
 	
-	#wes.setFontSize(QWebEngineSettings.DefaultFontSize, font_size)
-	wes.setFontSize(QWebEngineSettings.MinimumFontSize, font_size)
+	if hasattr(QWebEngineSettings, 'MinimumFontSize'):
+		wes.setFontSize(QWebEngineSettings.MinimumFontSize, font_size)
+	elif hasattr(QWebEngineSettings, 'FontSize'):
+		wes.setFontSize(QWebEngineSettings.FontSize.MinimumFontSize, font_size)
+
 
 def changeFontSize(config):
     font_size = config['font_size']


### PR DESCRIPTION
Seems like on the latest version of Anki + QT, this addon crashes (at least on Mac) since `MinimumFontSize` is missing from `QWebEngineSettings`. This fixes the issue as the value is now nested under an enum