### PR TITLE
Fix error finding attribute 'MinimumFontSize'

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -33,9 +33,13 @@ def changeWebFontSize(font_size):
 	except AttributeError:
 		# Qt5
 		wes = QWebEngineSettings.globalSettings()
-	
-	#wes.setFontSize(QWebEngineSettings.DefaultFontSize, font_size)
-	wes.setFontSize(QWebEngineSettings.MinimumFontSize, font_size)
+
+	try:
+		#wes.setFontSize(QWebEngineSettings.FontSize.DefaultFontSize, font_size)
+		wes.setFontSize(QWebEngineSettings.FontSize.MinimumFontSize, font_size)
+	except AttributeError:
+		#wes.setFontSize(QWebEngineSettings.DefaultFontSize, font_size)
+		wes.setFontSize(QWebEngineSettings.MinimumFontSize, font_size)
 
 def changeFontSize(config):
     font_size = config['font_size']


### PR DESCRIPTION
After upgrading to Aki 23.12.1 I started getting the following error:

```
Anki 23.12.1 (1a1d4d54)  (ao)
Python 3.9.15 Qt 6.5.3 PyQt 6.5.3
Platform: macOS-14.0-arm64-arm-64bit

When loading Set Font Size:
Traceback (most recent call last):
  File "aqt.addons", line 245, in loadAddons
  File "/Users/eloy/Library/Application Support/Anki2/addons21/651521808/__init__.py", line 45, in <module>
    changeFontSize(mw.addonManager.getConfig(__name__))
  File "/Users/eloy/Library/Application Support/Anki2/addons21/651521808/__init__.py", line 43, in changeFontSize
    changeWebFontSize(font_size)
  File "/Users/eloy/Library/Application Support/Anki2/addons21/651521808/__init__.py", line 38, in changeWebFontSize
    wes.setFontSize(QWebEngineSettings.MinimumFontSize, font_size)
AttributeError: type object 'QWebEngineSettings' has no attribute 'MinimumFontSize'
```

Looking at the extension's [Ankiweb page](https://ankiweb.net/shared/info/651521808), some users also seem to have trouble running the extension. Hopefully this fix will work for them as well.

## Areas of concern

> Did not test with PyQt5

I'm using PyQt6, so I'm not sure if this works with PyQt5 and I don't know how to make Anki use PyQt5 instead.
Looking at PyQt5's Web Engine file `QtWebEngineWidgets.py` it is similar but not fully equivalent to PyQt6 Web Engine's `QtWebEngineCore.py`:

``` py
# PyQt5 QtWebEngineWidgets.py
class QWebEngineSettings(PyQt5.sipsimplewrapper):
   ...
   # `int` instead of `enum.Enum` in PyQt6
    class FontSize(int):
        MinimumFontSize = ... # type: QWebEngineSettings.FontSize
        MinimumLogicalFontSize = ... # type: QWebEngineSettings.FontSize
        DefaultFontSize = ... # type: QWebEngineSettings.FontSize
        DefaultFixedFontSize = ... # type: QWebEngineSettings.FontSize

# PyQt6 QtWebEngineCore.py
class QWebEngineSettings(PyQt6.sip.simplewrapper):
   ...
    class FontSize(enum.Enum):
        MinimumFontSize = ... # type: QWebEngineSettings.FontSize
        MinimumLogicalFontSize = ... # type: QWebEngineSettings.FontSize
        DefaultFontSize = ... # type: QWebEngineSettings.FontSize
        DefaultFixedFontSize = ... # type: QWebEngineSettings.FontSize
```

So I used a try block just to be on the safe side.
